### PR TITLE
Add Entire .vscode Folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@
 *.app
 
 # VS code
-.vscode/settings.json
+.vscode


### PR DESCRIPTION
Updates the .gitignore file to ignore the whole .vscode folder.
