### PR TITLE
Delete Temp and Output Files Before Running

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,22 @@ compiles main.cpp file using dynamic link library. Outputs "main" executable
 g++ main.cpp [shared library name(.so file)] -o main -ldl
 ``` 
 
-## Commands to Build Dynamic Link Library (MAC)
+## Commands to Build Dynamic Link Library (MAC/Windows)
 
 ```sh
 g++ -std=c++17 -c -fPIC dll/ReduceDll.cpp -o libReduce.o
 g++ -std=c++17 -c -fPIC src/FileManager.cpp -o FileManager.o
 g++ -std=c++17 -c -fPIC dll/Map.cpp -o libMap.o
 
+# mac
 g++ -std=c++17 -shared -o libReduce.dylib libReduce.o FileManager.o
 g++ -std=c++17 -shared -o libMap.dylib libMap.o FileManager.o
 
-g++ -std=c++17 src/main.cpp src/Executive.cpp src/FileManager.cpp src/Map.cpp src/Sort.cpp src/Workflow.cpp -o main
+# windows
+g++ -std=c++17 -shared -o libReduce.dll libReduce.o FileManager.o
+g++ -std=c++17 -shared -o libMap.dll libMap.o FileManager.o
+
+g++ -std=c++17 src/main.cpp src/Executive.cpp src/FileManager.cpp src/Sort.cpp src/Workflow.cpp -o main
 
 ./main --inputDir data/input --tempDir data/temp --outputDir data/output --reduceDLL dll/mac/libReduce.dylib --mapDLL dll/mac/libMap.dylib 
 

--- a/src/Workflow.cpp
+++ b/src/Workflow.cpp
@@ -54,6 +54,8 @@ void Workflow::start() {
 #endif
 
   FileManager fm = FileManager();
+  fm.deleteFilesFromDir(tempDir);
+  fm.deleteFilesFromDir(outputDir);
   vector<string> inputFilePaths = fm.getFilesFromDir(inputDir);
 
   string tempMapOutputFilePath = tempDir + "/tempMapOutput.txt";


### PR DESCRIPTION
This adds FileManager calls to delete the files in the temp_data and output_data folders before doing any mapping and reducing. Also updates the readme for windows dll building instructions.

## Checklist

Please ensure that your pull request meets the following requirements:

- [ ] Code compiles without errors and warnings
- [ ] Code follows the project's coding style guidelines
- [ ] Code is tested and test cases pass
- [ ] Code has been reviewed by at least one other developer

## Related Issues

[If your pull request is related to any issues, link them here.]

## Additional Notes

[Include any additional information or notes that may be helpful in reviewing your pull request.]
